### PR TITLE
Standby mode wakeup by WKUP pin (PA0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ The following sketch disables ADC & GPIO's to save power before entering stop mo
       sleepAndWakeUp(STOP, &rt, alarmDelay);
     }
 
+## Standby mode with WKUP/Interrupt as exit mode
+Inital setup before enter standby mode that WKUP pin PA0 is set to LOW. 
+To exit or wakeup from standby mode give the PA0 logic HIGH.
+
+    #include <STM32Sleep.h>
+
+    void setup() {
+
+      // We have just started or woken up from sleep! System clock is set to 72MHz HSE.
+      delay(1000);
+      goToSleep(STANDBY);
+    }
+    
+    void loop() { }  // This is never run
+
 #Misc
 
 Thanks for the hard work & inspiration for all the people working on STM32duino!

--- a/STM32Sleep.cpp
+++ b/STM32Sleep.cpp
@@ -20,6 +20,7 @@ void goToSleep(SleepMode mode) {
 
     if (mode == STANDBY) {
       PWR_BASE->CR |= PWR_CR_PDDS;
+      PWR_BASE->CSR |= PWR_CSR_EWUP;
     }
 
     PWR_BASE->CR |= PWR_CR_LPDS;
@@ -27,7 +28,7 @@ void goToSleep(SleepMode mode) {
     SCB_BASE->SCR |= SCB_SCR_SLEEPDEEP;
 
     // Now go into stop mode, wake up on interrupt
-    asm("    wfi");  
+    asm("    wfi");
 }
 
 void disableAllPeripheralClocks() {


### PR DESCRIPTION
Another mode to exit standby mode is by set EWUP of PWR_BASE->CSR to enable the WKUP pin.